### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -322,7 +322,7 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 			}
 		}
 		if uid > 0 {
-			mr.uid = fmt.Sprintf("%d", uid)
+			mr.uid = strconv.Itoa(uid)
 		}
 	}
 

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -149,7 +149,7 @@ func valToBytes(v types.Val) ([]byte, error) {
 	case types.BinaryID:
 		return []byte(fmt.Sprintf("%q", v.Value)), nil
 	case types.IntID:
-		return []byte(fmt.Sprintf("%d", v.Value)), nil
+		return []byte(strconv.Itoa(v.Value)), nil
 	case types.FloatID:
 		return []byte(fmt.Sprintf("%f", v.Value)), nil
 	case types.BoolID:

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -142,7 +142,7 @@ func (w *grpcWorker) ReceivePredicate(stream pb.Worker_ReceivePredicateServer) e
 	for {
 		kvBatch, err := stream.Recv()
 		if err == io.EOF {
-			payload.Data = []byte(fmt.Sprintf("%d", count))
+			payload.Data = []byte(strconv.Itoa(count))
 			stream.SendAndClose(payload)
 			break
 		}


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```