### PR TITLE
Run comby over Go code to replace fmt.Sprintf with strconv.Itoa

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -322,7 +322,7 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 			}
 		}
 		if uid > 0 {
-			mr.uid = fmt.Sprintf("%d", uid)
+			mr.uid = strconv.Itoa(uid)
 		}
 	}
 

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -149,7 +149,7 @@ func valToBytes(v types.Val) ([]byte, error) {
 	case types.BinaryID:
 		return []byte(fmt.Sprintf("%q", v.Value)), nil
 	case types.IntID:
-		return []byte(fmt.Sprintf("%d", v.Value)), nil
+		return []byte(strconv.Itoa(v.Value)), nil
 	case types.FloatID:
 		return []byte(fmt.Sprintf("%f", v.Value)), nil
 	case types.BoolID:

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -142,7 +142,7 @@ func (w *grpcWorker) ReceivePredicate(stream pb.Worker_ReceivePredicateServer) e
 	for {
 		kvBatch, err := stream.Recv()
 		if err == io.EOF {
-			payload.Data = []byte(fmt.Sprintf("%d", count))
+			payload.Data = []byte(strconv.Itoa(count))
 			stream.SendAndClose(payload)
 			break
 		}


### PR DESCRIPTION
This campaign replaces calls to `fmt.Sprintf` in Go code with the equivalent `strconv.Itoa`

---

This pull request was created by a Sourcegraph campaign. [Click here to see the campaign](http://localhost:3080/campaigns/Q2FtcGFpZ246Mg==).